### PR TITLE
fix(admin): devel環境のGraphQLエンドポイントURLを修正

### DIFF
--- a/apps/admin/wrangler.devel.jsonc
+++ b/apps/admin/wrangler.devel.jsonc
@@ -15,6 +15,6 @@
     }
   ],
   "vars": {
-    "GRAPHQL_URL": "https://mimifuwacc-api-devel.mimifuwa.cc/graphql"
+    "GRAPHQL_URL": "https://mimifuwacc-api-devel.mimifuwacc.workers.dev/graphql"
   }
 }


### PR DESCRIPTION
- カスタムドメインからCloudflare WorkersデフォルトURLに変更
- https://mimifuwacc-api-devel.mimifuwa.cc/graphql
- → https://mimifuwacc-api-devel.mimifuwacc.workers.dev/graphql